### PR TITLE
Automated Changelog Entry for 0.1.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,18 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.1
+
+([Full Changelog](https://github.com/jupyterlite/xeus-sqlite-kernel/compare/first-commit...22f308f2c283513bd6d79f75f9f2de632f980876))
+
+### Maintenance and upkeep improvements
+
+- change repo owner from DerThorsten to jupyterlite [#1](https://github.com/jupyterlite/xeus-sqlite-kernel/pull/1) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-sqlite-kernel/graphs/contributors?from=2022-01-31&to=2022-01-31&type=c))
+
+[@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-sqlite-kernel+involves%3ADerThorsten+updated%3A2022-01-31..2022-01-31&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-sqlite-kernel+involves%3Ajtpio+updated%3A2022-01-31..2022-01-31&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-sqlite-kernel  |
| Branch  | main  |
| Version Spec | 0.1.1 |
| Since | first-commit |