### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Github Actions Status](https://github.com/jupyterlite/xeus-sqlite-kernel/workflows/Build/badge.svg)](https://github.com/jupyterlite/xeus-sqlite-kernel/actions/workflows/build.yml)
 
-A Sqlite kernel for JupyterLite running in the browser.
+A SQLite kernel for JupyterLite running in the browser.
 
+![jupyterlite-xeus-sqlite-kernel](https://user-images.githubusercontent.com/591645/151932680-5e568933-6e95-44aa-b34d-ff5c4f877559.png)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 A Sqlite kernel for JupyterLite running in the browser.
 
 
-
-
 ## Requirements
 
 - JupyterLite >= 0.1.0a14

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupyterlite/xeus-sqlite-kernel",
   "version": "0.1.1",
-  "description": "A sqlite kernel for JupyterLite, powered by Xeus",
+  "description": "A SQLite kernel for JupyterLite, powered by Xeus",
   "keywords": [
     "jupyter",
     "jupyterlab",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,14 +22,14 @@ const server_kernel: JupyterLiteServerPlugin<void> = {
   activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {
     kernelspecs.register({
       spec: {
-        name: 'Sqlite',
-        display_name: 'Sqlite',
+        name: 'SQLite',
+        display_name: 'SQLite',
         language: 'sql',
         argv: [],
         spec: {
           argv: [],
           env: {},
-          display_name: 'Sqlite',
+          display_name: 'SQLite',
           language: 'sql',
           interrupt_mode: 'message',
           metadata: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import logo32 from '../style/logos/sqlite-logo-32x32.png';
 import logo64 from '../style/logos/sqlite-logo-64x64.png';
 
 const server_kernel: JupyterLiteServerPlugin<void> = {
-  id: '@jupyterlite/xeus-kernel-extension:kernel',
+  id: '@jupyterlite/xeus-sqlite-kernel-extension:kernel',
   autoStart: true,
   requires: [IKernelSpecs],
   activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {


### PR DESCRIPTION
Follow-up to the `0.1.1` release:

- `SQLite` spelling
- Update the plugin id so it doesn't collide with another one that appears to be the same:

![image](https://user-images.githubusercontent.com/591645/151931980-6fcacce0-7f1a-44b1-a8bd-d935053947e6.png)
